### PR TITLE
fix: call potential only once and cache strategies

### DIFF
--- a/contracts/LenderDebtManager.sol
+++ b/contracts/LenderDebtManager.sol
@@ -150,7 +150,9 @@ contract LenderDebtManager {
                 _highest = i;
             }
         }
-        _potential = ILenderStrategy(_strategies[_highest]).aprAfterDebtChange(int256(toAdd));
+        _potential = ILenderStrategy(_strategies[_highest]).aprAfterDebtChange(
+            int256(toAdd)
+        );
     }
 
     // External function get the full array of strategies

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from utils.constants import MAX_INT, ROLES, WEEK
 
 # this should be the address of the ERC-20 used by the strategy/vault
 ASSET_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"  # USDC
-ASSET_WHALE_ADDRESS = "0xF977814e90dA44bFA03b6295A0616a897441aceC"  # USDC WHALE
+ASSET_WHALE_ADDRESS = "0x39aa39c021dfbae8fac545936693ac917d5e7563"  # USDC WHALE
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from utils.constants import MAX_INT, ROLES, WEEK
 
 # this should be the address of the ERC-20 used by the strategy/vault
 ASSET_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"  # USDC
-ASSET_WHALE_ADDRESS = "0x0A59649758aa4d66E25f08Dd01271e891fe52199"  # USDC WHALE
+ASSET_WHALE_ADDRESS = "0xF977814e90dA44bFA03b6295A0616a897441aceC"  # USDC WHALE
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_debt_manager.py
+++ b/tests/test_debt_manager.py
@@ -37,8 +37,8 @@ def test_rebalance(
     debt_manager = setup_debt_manager(vault, [strategy1, strategy2])
     tx_view = debt_manager.estimateAdjustPosition(sender=gov)
 
-    assert tx_view._lowest == 1  # strategy2
-    assert tx_view._highest == 0  # strategy1
+    assert tx_view._lowest == strategy2
+    assert tx_view._highest == strategy1
 
     vault.update_max_debt_for_strategy(strategy1.address, int(1e18), sender=gov)
     vault.update_max_debt_for_strategy(strategy2.address, int(1e18), sender=gov)
@@ -84,8 +84,8 @@ def test_rebalance__with_gain(
     debt_manager = setup_debt_manager(vault, [strategy1, strategy2])
     tx_view = debt_manager.estimateAdjustPosition(sender=gov)
 
-    assert tx_view._lowest == 1  # strategy2
-    assert tx_view._highest == 0  # strategy1
+    assert tx_view._lowest == strategy2
+    assert tx_view._highest == strategy1
 
     vault.update_max_debt_for_strategy(strategy1.address, int(1e18), sender=gov)
     vault.update_max_debt_for_strategy(strategy2.address, int(1e18), sender=gov)
@@ -134,8 +134,8 @@ def test_no_rebalance(
     debt_manager = setup_debt_manager(vault, [strategy1, strategy2])
     tx_view = debt_manager.estimateAdjustPosition(sender=gov)
 
-    assert tx_view._lowest == 1  # strategy2
-    assert tx_view._highest == 0  # strategy1
+    assert tx_view._lowest == strategy2
+    assert tx_view._highest == strategy1
 
     vault.update_max_debt_for_strategy(strategy1.address, int(1e18), sender=gov)
     vault.update_max_debt_for_strategy(strategy2.address, int(1e18), sender=gov)
@@ -184,8 +184,8 @@ def test_no_rebalance__adds_debt(
     debt_manager = setup_debt_manager(vault, [strategy1, strategy2])
     tx_view = debt_manager.estimateAdjustPosition(sender=gov)
 
-    assert tx_view._lowest == 1  # strategy2
-    assert tx_view._highest == 0  # strategy1
+    assert tx_view._lowest == strategy2
+    assert tx_view._highest == strategy1
 
     vault.update_max_debt_for_strategy(strategy1.address, int(1e18), sender=gov)
     vault.update_max_debt_for_strategy(strategy2.address, int(1e18), sender=gov)
@@ -231,8 +231,8 @@ def test_rebalance__with_min_idle(
     debt_manager = setup_debt_manager(vault, [strategy1, strategy2])
     tx_view = debt_manager.estimateAdjustPosition(sender=gov)
 
-    assert tx_view._lowest == 1  # strategy2
-    assert tx_view._highest == 0  # strategy1
+    assert tx_view._lowest == strategy2
+    assert tx_view._highest == strategy1
 
     vault.update_max_debt_for_strategy(strategy1.address, int(1e18), sender=gov)
     vault.update_max_debt_for_strategy(strategy2.address, int(1e18), sender=gov)
@@ -281,8 +281,8 @@ def test_rebalance__with_gain_and_min_idle(
     debt_manager = setup_debt_manager(vault, [strategy1, strategy2])
     tx_view = debt_manager.estimateAdjustPosition(sender=gov)
 
-    assert tx_view._lowest == 1  # strategy2
-    assert tx_view._highest == 0  # strategy1
+    assert tx_view._lowest == strategy2
+    assert tx_view._highest == strategy1
 
     vault.update_max_debt_for_strategy(strategy1.address, int(1e18), sender=gov)
     vault.update_max_debt_for_strategy(strategy2.address, int(1e18), sender=gov)
@@ -335,8 +335,8 @@ def test_no_rebalance__with_min_idle(
     debt_manager = setup_debt_manager(vault, [strategy1, strategy2])
     tx_view = debt_manager.estimateAdjustPosition(sender=gov)
 
-    assert tx_view._lowest == 1  # strategy2
-    assert tx_view._highest == 0  # strategy1
+    assert tx_view._lowest == strategy2
+    assert tx_view._highest == strategy1
 
     vault.update_max_debt_for_strategy(strategy1.address, int(1e18), sender=gov)
     vault.update_max_debt_for_strategy(strategy2.address, int(1e18), sender=gov)
@@ -388,8 +388,8 @@ def test_no_rebalance__adds_debt__with_min_idle(
     debt_manager = setup_debt_manager(vault, [strategy1, strategy2])
     tx_view = debt_manager.estimateAdjustPosition(sender=gov)
 
-    assert tx_view._lowest == 1  # strategy2
-    assert tx_view._highest == 0  # strategy1
+    assert tx_view._lowest == strategy2
+    assert tx_view._highest == strategy1
 
     vault.update_max_debt_for_strategy(strategy1.address, int(1e18), sender=gov)
     vault.update_max_debt_for_strategy(strategy2.address, int(1e18), sender=gov)


### PR DESCRIPTION
- get highestApr just with the idle amount and only call the highest strategy with the idle + lowest to test for the potential
- cache strategies array to save some gas
-  return the address in estimateAdjustPosition instead of the index, both more useful and saves gas.
- add some manual operations to tend/process report for if there is only 1 strategy or the same one always has the highest apr, since it wont process unless its the lowest